### PR TITLE
fix: type definiton

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.15",
   "description": "A Semaphore and MicroMix client library",
   "main": "build/index.js",
+  "types": "ts/index.ts",
   "scripts": {
     "watch": "tsc --watch",
     "build": "tsc",


### PR DESCRIPTION
Dependent applications currently do not detect the types in the module as shown:

![image](https://user-images.githubusercontent.com/7406870/103859048-58621f80-50f4-11eb-8305-443fba754ce6.png)

The fix allow dependent apps to detect the type def of the functions exported.